### PR TITLE
8.4 alpha1 is now upcoming

### DIFF
--- a/versions.php
+++ b/versions.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 $versions = [];
 
 if (getenv('INPUT_UPCOMINGRELEASES') == 'true') {
-    //$versions[] = '8.4.0alpha1';
+    $versions[] = '8.4.0alpha1';
 }
 
 $d = new DOMDocument();


### PR DESCRIPTION
Requires https://github.com/docker-library/php/pull/1526 to be completed, merged, and built so the images show up at https://hub.docker.com/_/php/tags?page=&page_size=&ordering=&name=8.4.0alpha1